### PR TITLE
fix(RN-0.71.x): resolve android build failure

### DIFF
--- a/android/packageDeprecated/src/main/java/com/swmansion/gesturehandler/RNGestureHandlerPackage.kt
+++ b/android/packageDeprecated/src/main/java/com/swmansion/gesturehandler/RNGestureHandlerPackage.kt
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler
 
-import com.facebook.react.BaseReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
@@ -19,7 +19,7 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerRootViewManager
     RNGestureHandlerModule::class
   ]
 )
-class RNGestureHandlerPackage : BaseReactPackage(), ViewManagerOnDemandReactPackage {
+class RNGestureHandlerPackage : TurboReactPackage(), ViewManagerOnDemandReactPackage {
   private val viewManagers: Map<String, ModuleSpec> by lazy {
     mapOf(
       RNGestureHandlerRootViewManager.REACT_CLASS to ModuleSpec.viewManagerSpec {
@@ -71,6 +71,7 @@ class RNGestureHandlerPackage : BaseReactPackage(), ViewManagerOnDemandReactPack
             RNGestureHandlerModule::class.java.name,
             reactModule.canOverrideExistingModule,
             reactModule.needsEagerInit,
+            true,
             reactModule.isCxxModule,
             true
           )


### PR DESCRIPTION
## Description

This PR addresses the Android build failure on React Native v0.71.x.

Note: This fix should not be included when building the package for later RN versions.