### PR TITLE
fix: ensure TypeScript spec files are included for codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-gesture-handler",
-  "version": "2.24.0-rc.9",
+  "version": "2.24.0-rc.10",
   "description": "Declarative API exposing native platform touch and gesture system to React Native",
   "scripts": {
     "prepare": "yarn build",
@@ -22,6 +22,7 @@
   "types": "src/index.d.ts",
   "files": [
     "src/**/*.js",
+    "src/**/*.ts",
     "src/**/*.d.ts",
     "!src/**/*.d.js",
     "!src/**/web",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "types": "src/index.d.ts",
   "files": [
     "src/**/*.js",
-    "src/**/*.ts",
+    "src/specs/**/*.ts",
     "src/**/*.d.ts",
     "!src/**/*.d.js",
     "!src/**/web",


### PR DESCRIPTION
## Description

Ensure TypeScript spec files are included in the npm package so codegen can process gesture handler modules correctly.

## Test plan

- Run `yarn build` then `npm pack` and verify `.ts `spec files are present in the output.
- Run the codegen script and confirm it processes gesture handler modules without errors.